### PR TITLE
Signal Fire

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/MaterialTag.java
@@ -552,6 +552,19 @@ public class MaterialTag implements ObjectTag, Adjustable {
         });
 
         // <--[tag]
+        // @attribute <MaterialTag.is_campfire>
+        // @returns ElementTag(Boolean)
+        // @group properties
+        // @description
+        // Returns whether the material is a campfire material.
+        // When this returns true, <@link tag MaterialTag.signal_fire>,
+        // and <@link mechanism MaterialTag.signal_fire> are accessible.
+        // -->
+        registerTag("is_campfire", (attribute, object) -> {
+            return new ElementTag(MaterialCampfire.describes(object));
+        });
+
+        // <--[tag]
         // @attribute <MaterialTag.is_levelable>
         // @returns ElementTag(Boolean)
         // @group properties

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -157,6 +157,9 @@ public class PropertyRegistry {
             PropertyParser.registerProperty(MaterialLightable.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialPersistent.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialPickle.class, MaterialTag.class);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14)) {
+                PropertyParser.registerProperty(MaterialCampfire.class, MaterialTag.class);
+            }
             PropertyParser.registerProperty(MaterialSlab.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialSnowable.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialSwitchable.class, MaterialTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -147,6 +147,9 @@ public class PropertyRegistry {
         // register core MaterialTag properties
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13)) {
             PropertyParser.registerProperty(MaterialAge.class, MaterialTag.class);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14)) {
+                PropertyParser.registerProperty(MaterialCampfire.class, MaterialTag.class);
+            }
             PropertyParser.registerProperty(MaterialDirectional.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialFaces.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialHalf.class, MaterialTag.class);
@@ -157,9 +160,6 @@ public class PropertyRegistry {
             PropertyParser.registerProperty(MaterialLightable.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialPersistent.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialPickle.class, MaterialTag.class);
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_14)) {
-                PropertyParser.registerProperty(MaterialCampfire.class, MaterialTag.class);
-            }
             PropertyParser.registerProperty(MaterialSlab.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialSnowable.class, MaterialTag.class);
             PropertyParser.registerProperty(MaterialSwitchable.class, MaterialTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialCampfire.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialCampfire.java
@@ -1,0 +1,85 @@
+package com.denizenscript.denizen.objects.properties.material;
+
+import com.denizenscript.denizen.objects.MaterialTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import org.bukkit.block.data.type.Campfire;
+
+public class MaterialCampfire implements Property {
+
+    public static boolean describes(ObjectTag material) {
+        return material instanceof MaterialTag
+                && ((MaterialTag) material).hasModernData()
+                && ((MaterialTag) material).getModernData().data instanceof Campfire;
+    }
+
+    public static MaterialCampfire getFrom(ObjectTag _material) {
+        if (!describes(_material)) {
+            return null;
+        }
+        else {
+            return new MaterialCampfire((MaterialTag) _material);
+        }
+    }
+
+    public static final String[] handledMechs = new String[] {
+            "signal_fire"
+    };
+
+
+    private MaterialCampfire(MaterialTag _material) {
+        material = _material;
+    }
+
+    MaterialTag material;
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <MaterialTag.signal_fire>
+        // @returns ElementTag(Boolean)
+        // @mechanism MaterialTag.signal_fire
+        // @group properties
+        // @description
+        // Returns whether this campfire will produce longer smoke trails, or not.
+        // -->
+        PropertyParser.<MaterialCampfire>registerTag("signal_fire", (attribute, material) -> {
+            return new ElementTag(material.getCampfire().isSignalFire());
+        });
+    }
+
+    public Campfire getCampfire() {
+        return (Campfire) material.getModernData().data;
+    }
+
+    @Override
+    public String getPropertyString() {
+        return String.valueOf(getCampfire().isSignalFire());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "signal_fire";
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object MaterialTag
+        // @name signal_fire
+        // @input ElementTag(Boolean)
+        // @description
+        // Sets a campfire block to have longer smoke trails, or not.
+        // @tags
+        // <MaterialTag.signal_fire>
+        // -->
+        if (mechanism.matches("signal_fire") && mechanism.requireBoolean()) {
+            getCampfire().setSignalFire(mechanism.getValue().asBoolean());
+        }
+    }
+}
+

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialSwitchable.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/material/MaterialSwitchable.java
@@ -44,6 +44,7 @@ public class MaterialSwitchable  implements Property {
         // <--[tag]
         // @attribute <MaterialTag.switched>
         // @returns ElementTag(Boolean)
+        // @mechanism MaterialTag.switched
         // @group properties
         // @description
         // Returns whether a Powerable material (like pressure plates) or an Openable material (like doors), or a dispenser is switched.


### PR DESCRIPTION
Implements `MaterialTag.signal_fire` tag and mechanism, and accompanying `MaterialTag.is_campfire`, also contains small meta fix for MaterialSwithable