### PR TITLE
Several additions for various entities.

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/PropertyRegistry.java
@@ -60,6 +60,9 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntityFramed.class, EntityTag.class);
         PropertyParser.registerProperty(EntityGravity.class, EntityTag.class);
         PropertyParser.registerProperty(EntityHealth.class, EntityTag.class);
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_15)) {
+            PropertyParser.registerProperty(EntityHive.class, EntityTag.class);
+        }
         PropertyParser.registerProperty(EntityInfected.class, EntityTag.class);
         PropertyParser.registerProperty(EntityInventory.class, EntityTag.class);
         PropertyParser.registerProperty(EntityIsShowingBottom.class, EntityTag.class);
@@ -85,6 +88,7 @@ public class PropertyRegistry {
         PropertyParser.registerProperty(EntitySkeleton.class, EntityTag.class);
         PropertyParser.registerProperty(EntitySpeed.class, EntityTag.class);
         PropertyParser.registerProperty(EntitySpell.class, EntityTag.class);
+        PropertyParser.registerProperty(EntityStrength.class, EntityTag.class);
         PropertyParser.registerProperty(EntityTame.class, EntityTag.class);
         PropertyParser.registerProperty(EntityTrades.class, EntityTag.class);
         PropertyParser.registerProperty(EntityVisible.class, EntityTag.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityHive.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityHive.java
@@ -11,7 +11,6 @@ import org.bukkit.block.Beehive;
 import org.bukkit.entity.Bee;
 import org.bukkit.entity.EntityType;
 
-
 public class EntityHive implements Property {
 
     public static boolean describes(ObjectTag entity) {

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityHive.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityHive.java
@@ -1,0 +1,142 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.block.Beehive;
+import org.bukkit.entity.Bee;
+import org.bukkit.entity.EntityType;
+
+
+public class EntityHive implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.BEE;
+    }
+
+    public static EntityHive getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        else {
+            return new EntityHive((EntityTag) entity);
+        }
+    }
+
+    public static final String[] handledTags = new String[] {
+            "hive", "has_hive"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "hive"
+    };
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityHive(EntityTag entity) {
+        bee = entity;
+    }
+
+    EntityTag bee;
+
+    /////////
+    // Property Methods
+    ///////
+
+    public boolean hasHive() {
+        if (((Bee) bee.getBukkitEntity()).getHive() != null) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    public boolean isHive(LocationTag location) {
+        if (location.getBlockState() instanceof Beehive) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    @Override
+    public String getPropertyString() {
+        if (hasHive()) {
+            return new LocationTag(((Bee) bee.getBukkitEntity()).getHive()).toString();
+        } else {
+            return "NONE";
+        }
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "hive";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.hive>
+        // @returns LocationTag
+        // @mechanism EntityTag.hive
+        // @group properties
+        // @description
+        // If the entity is a Bee, returns it's hive location.
+        // -->
+        if (attribute.startsWith("hive")) {
+            return new LocationTag(((Bee) bee.getBukkitEntity()).getHive())
+                    .getObjectAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.has_hive>
+        // @returns ElementTag(boolean)
+        // @group properties
+        // @description
+        // Returns whether or not this Bee has a hive.
+        // -->
+        if (attribute.startsWith("hive")) {
+            return new ElementTag(hasHive())
+                    .getObjectAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name hive
+        // @input LocationTag
+        // @description
+        // Sets the Hive location of a Bee
+        // @tags
+        // <EntityTag.hive>
+        // -->
+
+        if (mechanism.matches("hive")
+                && mechanism.requireObject(LocationTag.class)
+                && isHive(mechanism.valueAsType(LocationTag.class))) {
+            ((Bee) bee.getBukkitEntity()).setHive(mechanism.valueAsType(LocationTag.class));
+        }
+    }
+}

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityJumpStrength.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityJumpStrength.java
@@ -6,15 +6,19 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.Donkey;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
+import org.bukkit.entity.Mule;
 
 public class EntityJumpStrength implements Property {
 
 
     public static boolean describes(ObjectTag entity) {
         return entity instanceof EntityTag &&
-                ((EntityTag) entity).getBukkitEntityType() == EntityType.HORSE;
+                ((EntityTag) entity).getBukkitEntityType() == EntityType.HORSE ||
+                ((EntityTag) entity).getBukkitEntityType() == EntityType.DONKEY ||
+                ((EntityTag) entity).getBukkitEntityType() == EntityType.MULE;
     }
 
     public static EntityJumpStrength getFrom(ObjectTag entity) {
@@ -34,7 +38,6 @@ public class EntityJumpStrength implements Property {
             "jump_strength"
     };
 
-
     ///////////////////
     // Instance Fields and Methods
     /////////////
@@ -49,16 +52,47 @@ public class EntityJumpStrength implements Property {
     // Property Methods
     ///////
 
+    public boolean isMule() {
+        return entity.getBukkitEntityType() == EntityType.MULE;
+    }
+
+    public boolean isDonkey() {
+        return entity.getBukkitEntityType() == EntityType.DONKEY;
+    }
+
+    public double getJumpStrength() {
+        if (isMule()) {
+            return ((Mule) entity.getBukkitEntity()).getJumpStrength();
+        }
+        else if (isDonkey()) {
+            return ((Donkey) entity.getBukkitEntity()).getJumpStrength();
+        }
+        else {
+            return ((Horse) entity.getBukkitEntity()).getJumpStrength();
+        }
+    }
+
+    public void setJumpStrength(double i) {
+        if (isMule()) {
+            ((Mule) entity.getBukkitEntity()).setJumpStrength(i);
+        }
+        else if (isDonkey()) {
+            ((Donkey) entity.getBukkitEntity()).setJumpStrength(i);
+        }
+        else {
+            ((Horse) entity.getBukkitEntity()).setJumpStrength(i);
+        }
+    }
+
     @Override
     public String getPropertyString() {
-        return String.valueOf(((Horse) entity.getBukkitEntity()).getJumpStrength());
+        return String.valueOf(getJumpStrength());
     }
 
     @Override
     public String getPropertyId() {
         return "jump_strength";
     }
-
 
     ///////////
     // ObjectTag Attributes
@@ -80,10 +114,9 @@ public class EntityJumpStrength implements Property {
         // Returns the power of a horse's jump.
         // -->
         if (attribute.startsWith("jump_strength")) {
-            return new ElementTag(((Horse) entity.getBukkitEntity()).getJumpStrength())
+            return new ElementTag(getJumpStrength())
                     .getObjectAttribute(attribute.fulfill(1));
         }
-
         return null;
     }
 
@@ -99,9 +132,8 @@ public class EntityJumpStrength implements Property {
         // @tags
         // <EntityTag.jump_strength>
         // -->
-
         if (mechanism.matches("jump_strength") && mechanism.requireDouble()) {
-            ((Horse) entity.getBukkitEntity()).setJumpStrength(mechanism.getValue().asDouble());
+            setJumpStrength(mechanism.getValue().asDouble());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityStrength.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/properties/entity/EntityStrength.java
@@ -1,0 +1,109 @@
+package com.denizenscript.denizen.objects.properties.entity;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.tags.Attribute;
+import org.bukkit.entity.Llama;
+import org.bukkit.entity.EntityType;
+
+public class EntityStrength implements Property {
+
+    public static boolean describes(ObjectTag entity) {
+        return entity instanceof EntityTag && ((EntityTag) entity).getBukkitEntityType() == EntityType.LLAMA;
+    }
+
+    public static EntityStrength getFrom(ObjectTag entity) {
+        if (!describes(entity)) {
+            return null;
+        }
+        else {
+            return new EntityStrength((EntityTag) entity);
+        }
+    }
+
+    public static final String[] handledTags = new String[] {
+            "strength"
+    };
+
+    public static final String[] handledMechs = new String[] {
+            "strength"
+    };
+
+    ///////////////////
+    // Instance Fields and Methods
+    /////////////
+
+    private EntityStrength(EntityTag entity) {
+        dentity = entity;
+    }
+
+    EntityTag dentity;
+
+    /////////
+    // Property Methods
+    ///////
+
+    @Override
+    public String getPropertyString() {
+        return String.valueOf(((Llama) dentity.getBukkitEntity()).getStrength());
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "strength";
+    }
+
+    ///////////
+    // ObjectTag Attributes
+    ////////
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+
+        if (attribute == null) {
+            return null;
+        }
+
+        // <--[tag]
+        // @attribute <EntityTag.strength>
+        // @returns ElementTag(Number)
+        // @mechanism EntityTag.strength
+        // @group properties
+        // @description
+        // Returns the llama's strength that determines it's inventory, and intimidation level.
+        // -->
+        if (attribute.startsWith("strength")) {
+            return new ElementTag(((Llama) dentity.getBukkitEntity()).getStrength())
+                    .getObjectAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+
+        // <--[mechanism]
+        // @object EntityTag
+        // @name strength
+        // @input ElementTag(Number)
+        // @description
+        // set the llama's strength for determining it's inventory, and intimidation level.
+        // @tags
+        // <EntityTag.strength>
+        // -->
+
+        if (mechanism.matches("strength") && mechanism.requireInteger()) {
+            int strength = mechanism.getValue().asInt();
+            if (strength < 1 || strength > 5) {
+                Debug.echoError("Strength value '" + strength + "' is not valid. Must be between 1 and 5.");
+                return;
+            }
+            ((Llama) dentity.getBukkitEntity()).setStrength(mechanism.getValue().asInt());
+        }
+    }
+}


### PR DESCRIPTION
- Support for Mules and Donkeys to `EntityTag.jump_strength`
- Add new tag/mech for Llamas: `EntityTag.strength`. This value determines their inventory size, and intimidation level.
- Add new tag/mech for Bees: `EntityTag.hive`, also `EntityTag.has_hive`.